### PR TITLE
Additional Taxes (Other than VAT)

### DIFF
--- a/order.js
+++ b/order.js
@@ -200,10 +200,101 @@ let amazon_order_history_order = (function() {
                             }
                             return "N/A";
                         }.bind(this);
+                          const cad_gst = function(){
+                            let a = getField(
+                                ['GST', 'HST'].map(
+                                    label => sprintf(
+                                        '//div[contains(@id,"od-subtotals")]//' +
+                                        'span[contains(text(),"%s") and not(contains(.,"Before"))]/' +
+                                        'parent::div/following-sibling::div/span',
+                                        label
+                                    )
+                                ).join('|'),
+                                doc,
+                                doc.documentElement
+                            );
+                            if( a !== "?") {
+                                return a;
+                            }
+                            a = getField(
+                                '//*[text()[contains(.,"GST") and not(contains(.,"Before"))]]',
+                                doc,
+                                doc.documentElement
+                            );
+                            if( a !== null ) {
+                                const b = a.match(
+                                    /VAT: *([-$£€0-9.]*)/);
+                                if( b !== null ) {
+                                    return b[1];
+                                }
+                            }
+                            a = getField(
+                                '//div[contains(@class,"a-row pmts-summary-preview-single-item-amount")]//' +
+                                'span[contains(text(),"GST")]/' +
+                                'parent::div/following-sibling::div/span',
+                                doc,
+                                doc.documentElement
+                            );
+                            if( a !== null ) {
+                                const c = a.match(
+                                    /VAT: *([-$£€0-9.]*)/);
+                                if( c !== null ) {
+                                    return c[1];
+                                }
+                            }
+                            return "N/A";
+                        }.bind(this);
+
+                        const cad_pst = function(){
+                            let a = getField(
+                                ['PST', 'RST', 'QST'].map(
+                                    label => sprintf(
+                                        '//div[contains(@id,"od-subtotals")]//' +
+                                        'span[contains(text(),"%s") and not(contains(.,"Before"))]/' +
+                                        'parent::div/following-sibling::div/span',
+                                        label
+                                    )
+                                ).join('|'),
+                                doc,
+                                doc.documentElement
+                            );
+                            if( a !== "?") {
+                                return a;
+                            }
+                            a = getField(
+                                '//*[text()[contains(.,"PST") and not(contains(.,"Before"))]]',
+                                doc,
+                                doc.documentElement
+                            );
+                            if( a !== null ) {
+                                const b = a.match(
+                                    /VAT: *([-$£€0-9.]*)/);
+                                if( b !== null ) {
+                                    return b[1];
+                                }
+                            }
+                            a = getField(
+                                '//div[contains(@class,"a-row pmts-summary-preview-single-item-amount")]//' +
+                                'span[contains(text(),"PST")]/' +
+                                'parent::div/following-sibling::div/span',
+                                doc,
+                                doc.documentElement
+                            );
+                            if( a !== null ) {
+                                const c = a.match(
+                                    /VAT: *([-$£€0-9.]*)/);
+                                if( c !== null ) {
+                                    return c[1];
+                                }
+                            }
+                            return "N/A";
+                        }.bind(this);                        
                         resolve({
                             postage: postage(),
                             gift: gift(),
-                            vat: vat()
+                            vat: vat(),
+                            gst: cad_gst(),
+                            pst: cad_pst()
                         });
                     }.bind(this);
                     this.request_scheduler.schedule(

--- a/table.js
+++ b/table.js
@@ -68,6 +68,10 @@ const amazon_order_history_table = (function() {
         { field_name:'vat', type:'detail', property_name:'vat',
           is_numeric:true,
           help:'Caution: when stuff is not supplied by Amazon, then tax is often not listed.' },
+        { field_name:'GST', type:'detail', property_name:'gst',
+          is_numeric:true},
+       { field_name:'PST', type:'detail', property_name:'pst',
+          is_numeric:true},
         { field_name:'payments', type:'payments', property_name:'payments',
           is_numeric:false },
     ];


### PR DESCRIPTION
On amazon.ca we have additional taxes to track, namely GST/HST and PST/RST/QST. I've forked and modified this copy to report them. But some extra work is needed to not show them to other regions where there won't be GST/PST.

![image](https://user-images.githubusercontent.com/15116767/42129529-0006aea6-7c84-11e8-989f-72e9105a0dbc.png)
