### PR TITLE
Adds refunds column

### DIFF
--- a/order.js
+++ b/order.js
@@ -312,13 +312,32 @@ const amazon_order_history_order = (function() {
                                 }
                             }
                             return "N/A";
-                        }.bind(this);                        
+                        }.bind(this);
+                        const refund = function () {
+                            let a = getField(
+                                ['Refund'].map( //TODO other field names?
+                                    label => sprintf(
+                                        '//div[contains(@id,"od-subtotals")]//' +
+                                        'span[contains(text(),"%s")]/' +
+                                        'ancestor::div[1]/following-sibling::div/span',
+                                        label
+                                    )
+                                ).join('|'),
+                                doc,
+                                doc.documentElement
+                            );
+                            if (a !== "?") {
+                                return a;
+                            }
+                            return "N/A";
+                        }.bind(this);
                         resolve({
                             postage: postage(),
                             gift: gift(),
                             vat: vat(),
                             gst: cad_gst(),
-                            pst: cad_pst()
+                            pst: cad_pst(),
+                            refund: refund()
                         });
                     }.bind(this);
                     this.request_scheduler.schedule(

--- a/order.js
+++ b/order.js
@@ -163,7 +163,7 @@ const amazon_order_history_order = (function() {
                         }.bind(this);
                         const postage = function() {
                             let a = getField(
-                                ['Postage', 'Shipping', 'Livraison'].map(
+                                ['Postage', 'Shipping', 'Livraison', 'Delivery'].map(
                                     label => sprintf(
                                         '//div[contains(@id,"od-subtotals")]//' +
                                         'span[contains(text(),"%s")]/' +

--- a/table.js
+++ b/table.js
@@ -112,6 +112,12 @@ const amazon_order_history_table = (function() {
             sites: ['www.amazon.ca', 'smile.amazon.ca'],
         },
         {
+            field_name: 'refund',
+            type: 'detail',
+            property_name: 'refund',
+            is_numeric: true,
+        },
+        {
             field_name: 'payments',
             type: 'payments',
             property_name: 'payments',


### PR DESCRIPTION
As discussed in issue #25 this parses the total refunded value of an order and adds a column for it in the output. I only tested it with my amazon account (amazon.de), maybe we need more different search strings than only "Refund".