### PR TITLE
Fix missing payments, and a crash when Payment Method contains a slash

### DIFF
--- a/extraction.js
+++ b/extraction.js
@@ -75,7 +75,7 @@ const amazon_order_history_extraction = (function() {
             );
             // "Item(s) Subtotal: GBP 9.63 Shipping & Handling: GBP 4.24 ----- Total before tax: GBP 13.87 Estimated tax to be collected: GBP 1.22 ----- Grand Total: GBP 15.09 Payment Method: American Express | Last digits: 1416 Billing address Mr Philip Mulcahy Somewhere in the UK"
             const card_names = new_style_payments.map(
-                s => /Payment Method: ([A-Za-z0-9 ]*) \|/.exec(s)[1].trim()
+                s => /Payment Method: ([A-Za-z0-9 /]*) \|/.exec(s)[1].trim()
             );
             const card_number_suffixes = new_style_payments.map(
                 s => /Last digits: (\d+)/.exec(s)[1]

--- a/extraction.js
+++ b/extraction.js
@@ -65,6 +65,7 @@ const amazon_order_history_extraction = (function() {
                           .replace(/  */g, '\xa0')  //&nbsp;
                           .trim();
             });
+            return payments;
         };
         const strategy_2 = () => {
             const new_style_payments = amazon_order_history_util.findMultipleNodeValues(
@@ -83,12 +84,13 @@ const amazon_order_history_extraction = (function() {
             const payment_amounts = new_style_payments.map(
                 s => /Grand Total: (.*) Payment Method/.exec(s)[1].trim()
             );
-            const count = Math.min( [card_names, card_number_suffixes, payment_amounts].map( l => l.length ) );
+            const count = Math.min( ...[card_names, card_number_suffixes, payment_amounts].map( l => l.length ) );
             const payments = [];
             let i = 0;
             for ( i = 0; i < count; i++ ) {
                 payments.push( card_names[i] + ' ending in ' + card_number_suffixes[i] + ': ' + payment_amounts[i] );
             }
+            return payments;
         };
         const strategies = [strategy_1, strategy_2];
         let i = 0;


### PR DESCRIPTION
Fix crash when Payment Method contains a slash, for example "Visa/Delta/Electron"