### PR TITLE
[WIP] Make XPath patterns more general to fix some extraction failures

### DIFF
--- a/src/js/order_details.ts
+++ b/src/js/order_details.ts
@@ -170,9 +170,9 @@ function extractDetailFromDoc(
         '//span[contains(@id,"grand-total-amount")]/text()',
 
         '//div[contains(@id,"od-subtotals")]//' +
-        '*[contains(text(),"Grand Total") ' +
-        'or contains(text(),"Montant total TTC")' +
-        'or contains(text(),"Total général du paiement")' +
+        '*[.//text()[contains(.,"Grand Total")] ' +
+        'or .//text()[contains(.,"Montant total TTC")]' +
+        'or .//text()[contains(.,"Total général du paiement")]' +
         ']/parent::div/following-sibling::div/span',
 
         '//span[contains(text(),"Grand Total:")]' +
@@ -215,7 +215,7 @@ function extractDetailFromDoc(
     const a = extraction.by_regex(
       [
         '//div[contains(@id,"od-subtotals")]//' +
-        'span[contains(text(),"Gift") or contains(text(),"Importo Buono Regalo")]/' +
+        'span[.//text()[contains(.,"Gift")] or .//text()[contains(.,"Importo Buono Regalo")]]/' +
         'parent::div/following-sibling::div/span',
 
         '//span[contains(@id, "giftCardAmount-amount")]/text()', // Whole foods or Amazon Fresh.
@@ -249,7 +249,7 @@ function extractDetailFromDoc(
           ['Postage', 'Shipping', 'Livraison', 'Delivery', 'Costi di spedizione'].map(
             label => sprintf.sprintf(
               '//div[contains(@id,"od-subtotals")]//' +
-              'span[contains(text(),"%s")]/' +
+              'span[.//text()[contains(.,"%s")]]/' +
               'parent::div/following-sibling::div/span',
               label
             )
@@ -271,7 +271,7 @@ function extractDetailFromDoc(
           ['FREE Shipping'].map(
             label => sprintf.sprintf(
               '//div[contains(@id,"od-subtotals")]//' +
-              'span[contains(text(),"%s")]/' +
+              'span[.//text()[contains(.,"%s")]]/' +
               'parent::div/following-sibling::div/span',
               label
             )
@@ -340,7 +340,7 @@ function extractDetailFromDoc(
     let a = extraction.by_regex(
       [
         '//div[text() = "Tax Collected:"]/following-sibling::div/text()',
-        '//span[contains(text(),"Estimated tax to be collected:")]/../../div[2]/span/text()',
+        '//span[.//text()[contains(.,"Estimated tax to be collected:")]]/../../div[2]/span/text()',
         '//span[contains(@id, "totalTax-amount")]/text()',
       ],
       util.moneyRegEx(),
@@ -426,7 +426,7 @@ function extractDetailFromDoc(
       ].map(
         label => sprintf.sprintf(
           '//div[contains(@id,"od-subtotals")]//' +
-          'span[contains(text(),"%s")]/' +
+          'span[.//text()[contains(.,"%s")]]/' +
           'ancestor::div[1]/following-sibling::div/span',
           label
         )


### PR DESCRIPTION
This is a fix for https://github.com/philipmulcahy/azad/issues/321

In short, makes some of the XPaths search down in cases where there are multiple span tags wrapping a textual label. (The textual labels are then used as "anchor points" to find the corresponding values.)

I've locally written a couple unit tests (one against an already-working order detail page, one against a broken order detail page) that show that my fix in that PR is working at least for total, shipping and tax fields.
(I don't have cases for the other fields but I fixed them in the same way.)

I tried scrubbing the PII from the order detail pages I used for my tests but it turned out to be harder than I expected, so I'm not including them in the PR.

I have also done a large-scale test that shows my fix works. Here's a screenshot with all data.
![image](https://github.com/user-attachments/assets/f54c042e-6053-45f1-a708-bd28bb4bd65b)
