### PR TITLE
Fix scraping of canadian GST/HST/PST

### DIFF
--- a/src/js/order_details.ts
+++ b/src/js/order_details.ts
@@ -384,7 +384,7 @@ function extractDetailFromDoc(
       [
         ['GST', 'HST'].map(
           label => sprintf.sprintf(
-            '//div[contains(@id,"od-subtotals")]//span[contains(text(),"%s") and not(contains(.,"Before"))]/parent::div/following-sibling::div/span',
+            '//div[contains(@id,"od-subtotals")]//span[contains(text(),"%s") and not(contains(.,"Before"))]/ancestor::div[position()=1]/following-sibling::div/span',
             label
           )
         ).join('|'),
@@ -404,7 +404,7 @@ function extractDetailFromDoc(
       [
         ['PST', 'RST', 'QST'].map(
           label => sprintf.sprintf(
-            '//div[contains(@id,"od-subtotals")]//span[contains(text(),"%s") and not(contains(.,"Before"))]/parent::div/following-sibling::div/span',
+            '//div[contains(@id,"od-subtotals")]//span[contains(text(),"%s") and not(contains(.,"Before"))]/ancestor::div[position()=1]/following-sibling::div/span',
             label
           )
         ).join('|'),


### PR DESCRIPTION
It would seem some `amazon.ca` orders nest the `span`s containing GST/HST and PST inside another span, instead of directly having the `span` be a child of the `div`. This doesn't happen for every single order, but seems to be the case of 90%+ of my orders in 2025. This results in the GST/PST fields in the report being filled with text instead of actual dollar values.

This is a simple xpath change which gets the first ancestor `div` instead of the parent `div` - making it still compatible with "old-style" orders.

Before:
![image](https://github.com/user-attachments/assets/dc41c934-c3cb-4e98-837a-323af5699a27)

After:
![image](https://github.com/user-attachments/assets/56ac17c3-9b05-455c-ad41-bfd9579ac6b6)
